### PR TITLE
Fix crash when creating and deleting telepathy accounts directly

### DIFF
--- a/mcp-account-manager-uoa/mcp-account-manager-uoa.c
+++ b/mcp-account-manager-uoa/mcp-account-manager-uoa.c
@@ -749,48 +749,8 @@ account_manager_uoa_create (const McpAccountStorage *storage,
     GHashTable *params,
     GError **error)
 {
-  McpAccountManagerUoa *self = (McpAccountManagerUoa *) storage;
-  gchar *account_name;
-  AgAccount *account;
-  AgAccountService *service;
-  GList *l;
-
-  g_return_val_if_fail (self->priv->manager != NULL, NULL);
-
-  if (!self->priv->ready)
-    {
-      g_set_error (error, TP_ERROR, TP_ERROR_INVALID_ARGUMENT,
-          "Cannot create account before being ready");
-      return NULL;
-    }
-
-  DEBUG (G_STRFUNC);
-
-  /* Create a new AgAccountService and keep it internally. This won't save it
-   * into persistent storage until account_manager_uoa_commit() is called.
-   * We assume there is only one IM service */
-  account = ag_manager_create_account (self->priv->manager, protocol_name);
-  l = ag_account_list_services_by_type (account, SERVICE_TYPE);
-  if (l == NULL)
-    {
-      g_set_error (error, TP_ERROR, TP_ERROR_INVALID_ARGUMENT,
-          "Cannot create a %s service for %s provider",
-          SERVICE_TYPE, protocol_name);
-      g_object_unref (account);
-      return NULL;
-    }
-  service = ag_account_service_new (account, l->data);
-  ag_service_list_free (l);
-  g_object_unref (account);
-
-  account_name = mcp_account_manager_get_unique_name (self->priv->am,
-      cm_name, protocol_name, params);
-  _service_set_tp_account_name (service, account_name);
-  g_assert (_add_service (self, service, account_name));
-
-  /* MC will set all params on the account and commit */
-
-  return account_name;
+  /* We don't want account creation for this plugin. */
+  return NULL;
 }
 
 static gboolean
@@ -799,31 +759,7 @@ account_manager_uoa_delete (const McpAccountStorage *storage,
     const gchar *account_name,
     const gchar *key)
 {
-  McpAccountManagerUoa *self = (McpAccountManagerUoa *) storage;
-  AgAccountService *service;
-  AgAccount *account;
-
-  g_return_val_if_fail (self->priv->manager != NULL, FALSE);
-
-  service = g_hash_table_lookup (self->priv->accounts, account_name);
-  if (service == NULL)
-    return FALSE;
-
-  account = ag_account_service_get_account (service);
-
-  DEBUG ("%s: %s, %s", G_STRFUNC, account_name, key);
-
-  if (key == NULL)
-    {
-      ag_account_delete (account);
-      g_hash_table_remove (self->priv->accounts, account_name);
-    }
-  else
-    {
-      _service_set_tp_value (service, key, NULL);
-    }
-
-  return TRUE;
+  return FALSE;
 }
 
 static gboolean


### PR DESCRIPTION
Apparently, these functions must be implemented, and will be ignored if they return NULL.
