### PR TITLE
[telepathy-sasl-signon] Build Facebook authentication responses without libsoup

### DIFF
--- a/rpm/telepathy-accounts-signon.spec
+++ b/rpm/telepathy-accounts-signon.spec
@@ -13,7 +13,6 @@ BuildRequires: pkgconfig(gobject-2.0)
 BuildRequires: pkgconfig(libsignon-glib)
 BuildRequires: pkgconfig(telepathy-glib)
 BuildRequires: pkgconfig(libaccounts-glib)
-BuildRequires: pkgconfig(libsoup-2.4)
 BuildRequires: pkgconfig(mission-control-plugins)
 
 BuildRequires: pkgconfig(libsailfishkeyprovider)

--- a/telepathy-sasl-signon/telepathy-sasl-signon.pro
+++ b/telepathy-sasl-signon/telepathy-sasl-signon.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 CONFIG -= qt
 
 CONFIG += link_pkgconfig
-PKGCONFIG += libsignon-glib telepathy-glib libaccounts-glib libsoup-2.4
+PKGCONFIG += libsignon-glib telepathy-glib libaccounts-glib
 PKGCONFIG += libsailfishkeyprovider
 
 DEFINES += HAVE_UOA \


### PR DESCRIPTION
libsoup would escape parameters too much, resulting in authentication
failures with some recent server-side changes by Facebook. The response
string is simple to build and escaping is unnecessary for all feasible
inputs.
