### PR TITLE
[telepathy-sasl-signon] Use booster for launching

### DIFF
--- a/rpm/telepathy-accounts-signon.spec
+++ b/rpm/telepathy-accounts-signon.spec
@@ -14,8 +14,9 @@ BuildRequires: pkgconfig(libsignon-glib)
 BuildRequires: pkgconfig(telepathy-glib)
 BuildRequires: pkgconfig(libaccounts-glib)
 BuildRequires: pkgconfig(mission-control-plugins)
-
 BuildRequires: pkgconfig(libsailfishkeyprovider)
+
+Requires: mapplauncherd
 
 %description
 %{summary}.

--- a/telepathy-sasl-signon/org.freedesktop.Telepathy.Client.SaslSignonAuth.service
+++ b/telepathy-sasl-signon/org.freedesktop.Telepathy.Client.SaslSignonAuth.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.freedesktop.Telepathy.Client.SaslSignonAuth
-Exec=/usr/libexec/telepathy-sasl-signon
+Exec=/usr/bin/invoker --type=generic /usr/libexec/telepathy-sasl-signon


### PR DESCRIPTION
libsailfishkeyprovider is a privileged resource, so we need to launch
via the booster to gain privileges. Some careful systemd work related to
mission-control-5 will be done to make sure that booster-generic is
alwyas available when necessary.
